### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   flake8:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Violet-Site-Systems/metta-examples/security/code-scanning/2](https://github.com/Violet-Site-Systems/metta-examples/security/code-scanning/2)

To address this issue, the workflow requires an explicit `permissions` block to limit the access granted to the `GITHUB_TOKEN`. Since this is a linting workflow that only reads the code and does not modify the repository, the appropriate permissions are `contents: read`. This ensures the workflow operates securely with the least privilege necessary.

Changes will be made to the root level of the workflow (`lint.yml`) to add the `permissions` key, limiting permissions globally for all jobs in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
